### PR TITLE
feat: add database seeding functionality for real estate app

### DIFF
--- a/app/(root)/(tabs)/index.tsx
+++ b/app/(root)/(tabs)/index.tsx
@@ -1,5 +1,6 @@
 import {
 ActivityIndicator,
+    Button,
 FlatList,
 Image,
 Text,
@@ -21,6 +22,7 @@ import { Card, FeaturedCard } from "@/components/Cards";
 import { useAppwrite } from "@/lib/useAppwrite";
 import { useGlobalContext } from "@/lib/global-provider";
 import { getLatestProperties, getProperties } from "@/lib/appwrite";
+// import seed from "@/lib/seed";
 
 const Home = () => {
 const { user } = useGlobalContext();
@@ -58,6 +60,7 @@ const handleCardPress = (id: string) => router.push(`/properties/${id}`);
 
 return (
     <SafeAreaView className="h-full bg-white">
+    {/* <Button title="Seed" onPress={seed}></Button> */}
     <FlatList
         data={properties}
         numColumns={2}

--- a/lib/seed.ts
+++ b/lib/seed.ts
@@ -16,24 +16,21 @@ const COLLECTIONS = {
 
 const propertyTypes = [
   "House",
-  "Townhomes",
-  "Condos",
-  "Duplexes",
-  "Studios",
+  "Townhouse",
+  "Condo",
+  "Duplex",
+  "Studio",
   "Villa",
-  "Apartments",
-  "Others",
+  "Apartment",
+  "Other",
 ];
 
 const facilities = [
   "Laundry",
-  "Car Parking",
-  "Sports Center",
-  "Cutlery",
+  "Parking",
   "Gym",
-  "Swimming pool",
   "Wifi",
-  "Pet Center",
+  "Pet-friendly",
 ];
 
 function getRandomSubset<T>(


### PR DESCRIPTION
# Database Seeding Implementation

Adds functionality to seed the Appwrite database with sample real estate data:
- 5 agents with randomized avatars
- 20 reviews with random ratings
- Gallery images for properties
- 20 properties with randomized details

## Key Changes
- Add seed.ts with data generation logic
- Update env variable references for collection IDs
- Implement random subset selection for reviews and galleries
- Add seeding button to home screen (commented)
