### PR TITLE
fix: update bookings collection permissions

### DIFF
--- a/app/(root)/(tabs)/bookings.tsx
+++ b/app/(root)/(tabs)/bookings.tsx
@@ -110,12 +110,19 @@ const BookingsScreen = () => {
 
     if (error) {
         return (
-            <View className="flex-1 justify-center items-center">
-                <Text className="text-danger font-rubik-medium">{error}</Text>
+            <View className="flex-1 justify-center items-center bg-white">
+                <Text className="text-danger text-base font-rubik-medium text-center px-4">
+                    {error}
+                </Text>
+                <TouchableOpacity 
+                    onPress={fetchBookings}
+                    className="mt-4 bg-primary-300 px-6 py-2 rounded-full"
+                >
+                    <Text className="text-white font-rubik-medium">Try Again</Text>
+                </TouchableOpacity>
             </View>
         );
     }
-
     return (
         <SafeAreaView className="flex-1 bg-white">
             <View className="flex-row items-center justify-between px-5 py-4">

--- a/lib/appwrite.ts
+++ b/lib/appwrite.ts
@@ -26,6 +26,7 @@ import {
     propertiesCollectionId:
       process.env.EXPO_PUBLIC_APPWRITE_PROPERTIES_COLLECTION_ID,
     favoritesCollectionId: process.env.EXPO_PUBLIC_APPWRITE_FAVORITES_COLLECTION_ID,
+    bookingsCollectionId: process.env.EXPO_PUBLIC_APPWRITE_BOOKINGS_COLLECTION_ID,
     bucketId: process.env.EXPO_PUBLIC_APPWRITE_BUCKET_ID,
   };
   
@@ -382,7 +383,7 @@ import {
 
         const booking = await databases.createDocument(
             config.databaseId!,
-            BOOKINGS_COLLECTION_ID!,
+            config.bookingsCollectionId!, // Changed from BOOKINGS_COLLECTION_ID
             ID.unique(),
             {
                 property_id,
@@ -417,7 +418,7 @@ export async function getUserBookings(status?: BookingStatus) {
 
         const result = await databases.listDocuments(
             config.databaseId!,
-            BOOKINGS_COLLECTION_ID!,
+            config.bookingsCollectionId!, // Changed from BOOKINGS_COLLECTION_ID
             queries
         );
 
@@ -435,7 +436,7 @@ export async function updateBookingStatus(
     try {
         const booking = await databases.updateDocument(
             config.databaseId!,
-            BOOKINGS_COLLECTION_ID!,
+            config.bookingsCollectionId!, // Changed from BOOKINGS_COLLECTION_ID
             bookingId,
             {
                 status,
@@ -458,7 +459,7 @@ export async function checkTimeSlotAvailability(
     try {
         const result = await databases.listDocuments(
             config.databaseId!,
-            BOOKINGS_COLLECTION_ID!,
+            config.bookingsCollectionId!, // Changed from BOOKINGS_COLLECTION_ID
             [
                 Query.equal('property_id', property_id),
                 Query.equal('date', date),


### PR DESCRIPTION
## Fix Bookings Collection Permissions

### Problem
Users were unable to access the bookings functionality due to authorization errors with the Appwrite collection permissions.

### Solution
- Updated bookings collection permissions in Appwrite:
  - Added `user:{user.$id}` role with full CRUD permissions
  - Added `Users` role with CREATE-only permission
  - Removed overly permissive "Any" role
- These changes ensure:
  - Users can only access their own bookings
  - Any authenticated user can create new bookings
  - Proper data isolation between users
  - Secure access control





